### PR TITLE
Make xorshift compile with gcc version 4.6.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import numpy
 import os
 
 # Suppress unused function warnings from clang arising in numpy code
-os.environ['CFLAGS'] = '%s %s' % (os.environ.get('CFLAGS', ''), '-Wno-unused-function')
+os.environ['CFLAGS'] = '%s %s' % (os.environ.get('CFLAGS', ''), '-Wno-unused-function -std=c99')
 
 setup(
     name='xorshift',

--- a/xorshift/xoroshiro.c
+++ b/xorshift/xoroshiro.c
@@ -149,7 +149,7 @@ void xoroshiro(xor_rng_state* state, float* buf, size_t len)
     return;
 }
 
-static inline __m128 xorshift128plus_vector_advance(__m128i* s0,
+static inline __m128i xorshift128plus_vector_advance(__m128i* s0,
                                                             __m128i* s1)
 {
     __m128i xmm1 = *s0;

--- a/xorshift/xoroshiro.h
+++ b/xorshift/xoroshiro.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <emmintrin.h> /* SSE2 */
+#include <stdint.h>
 
 typedef struct _xor_rng_state {
     __m128i s0;


### PR DESCRIPTION
When compiling with gcc v 4.6.3 I got the following errors:

```
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -I/home/eerik/local/include -I/home/eerik/local/include/ncurses/ -Wno-unused-function -fPIC -I/home/eerik/xorshift/.venv/local/lib/python2.7/site-packages/numpy/core/include -I/usr/include/python2.7 -c xorshift/xoroshiro.c -o build/temp.linux-x86_64-2.7/xorshift/xoroshiro.o
    In file included from xorshift/xoroshiro.c:4:0:
    xorshift/xoroshiro.h:9:37: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.h:15:49: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:8:1: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:8:28: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:14:1: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:14:1: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:17:38: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:25:43: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:52:44: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c:59:49: error: unknown type name ‘uint64_t’
    xorshift/xoroshiro.c: In function ‘xoroshiro_vector_advance’:
    xorshift/xoroshiro.c:110:13: warning: unused variable ‘xmm0’ [-Wunused-variable]
    xorshift/xoroshiro.c: In function ‘xorshift128plus_vector_advance’:
    xorshift/xoroshiro.c:176:5: error: incompatible types when returning type ‘__m128i’ but ‘__m128’ was expected
    xorshift/xoroshiro.c:157:13: warning: unused variable ‘xmm0’ [-Wunused-variable]
    xorshift/xoroshiro.c: In function ‘xorshift128plus’:
    xorshift/xoroshiro.c:191:26: error: incompatible type for argument 1 of ‘random_bits_to_uniform_0_1’
    xorshift/xoroshiro.c:101:22: note: expected ‘__m128i’ but argument is of type ‘__m128’
    xorshift/xoroshiro.c: In function ‘xoroshiro_binomial’:
    xorshift/xoroshiro.c:214:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
    xorshift/xoroshiro.c:214:5: note: use option -std=c99 or -std=gnu99 to compile your code
    xorshift/xoroshiro.c:216:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
    xorshift/xoroshiro.c: In function ‘xorshift128plus_binomial’:
    xorshift/xoroshiro.c:246:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
    xorshift/xoroshiro.c:248:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
    xorshift/xoroshiro.c:251:25: error: incompatible type for argument 1 of ‘random_bits_to_uniform_1_2’
    xorshift/xoroshiro.c:88:22: note: expected ‘__m128i’ but argument is of type ‘__m128’
    error: command 'gcc' failed with exit status 1
```

The changes in this PR make xorshift compile. All tests pass.
